### PR TITLE
Update openssl.cnf

### DIFF
--- a/etc/openssl.cnf
+++ b/etc/openssl.cnf
@@ -3,7 +3,7 @@ default_ca	= CA_default		# The default ca section
 
 [ CA_default ]
 
-dir = /home/pi/dshield/bin//../etc/CA
+dir = /home/dshield/dshield/bin//../etc/CA
 certs		= $dir/certs		# Where the issued certs are kept
 crl_dir = $dir/crls
 database	= $dir/index.txt	# database index file.


### PR DESCRIPTION
CA dir seems to have been changed inadvertently from /home/dshield/... to /home/pi/... 
Users that are running as 'pi' user can create a symlink so they don't have to change this path.